### PR TITLE
Fix serialization for Sotlinx Instant

### DIFF
--- a/src/pages/Deployments/ParticipantRecord/index.tsx
+++ b/src/pages/Deployments/ParticipantRecord/index.tsx
@@ -49,13 +49,20 @@ const ParticipantRecord = ({
   );
   const participantDeviceType = primaryDevice.device.__type;
   const deviceStatus = primaryDevice.__type.split(".").pop();
+  if (participantData.firstName === undefined) {
+    participantData.firstName = "";
+  }
+  if (participantData.lastName === undefined) {
+    participantData.lastName = "";
+  }
+
   const lastDataUpload = useMemo(() => {
     const lastData = participantData.dateOfLastDataUpload;
-    if (lastData === null) {
+    if (lastData === null || lastData === undefined) {
       return "";
     }
     const elapsedDays = calculateDaysPassedFromDate(
-      lastData.value$kotlinx_datetime.toString(),
+      lastData.toString(),
     );
     if (elapsedDays === 0) {
       return "Last data: Today";

--- a/src/pages/Participant/Deployment/index.tsx
+++ b/src/pages/Participant/Deployment/index.tsx
@@ -62,22 +62,19 @@ const Deployment = () => {
     createSummary.mutateAsync({ studyId, deploymentIds: [deploymentId] });
   };
 
-  const lastDataUpload = (lastData: {
-    epocSeconds: number;
-    value$kotlinx_datetime: Date;
-    nanosecondsOfSecond: number;
-  }) => {
-    if (lastData === null) {
+  const lastDataUpload = (lastData: Date
+  ) => {
+    if (lastData === null || lastData === undefined) {
       return "";
     }
     if (
       calculateDaysPassedFromDate(
-        lastData.value$kotlinx_datetime.toString(),
+        lastData.toString(),
       ) === 0
     ) {
       return "Last data: Today";
     }
-    return `Last data: ${calculateDaysPassedFromDate(lastData.value$kotlinx_datetime.toString())} days ago`;
+    return `Last data: ${calculateDaysPassedFromDate(lastData.toString())} days ago`;
   };
 
   useEffect(() => {
@@ -130,8 +127,10 @@ const Deployment = () => {
     if (
       participant.firstName === "" ||
       participant.firstName === null ||
+      participant.firstName === undefined ||
       participant.lastName === "" ||
-      participant.lastName === null
+      participant.lastName === null ||
+      participant.lastName === undefined
     ) {
       return participant.role ? participant.role[0] : "?";
     }

--- a/src/pages/Studies/StudiesSection/index.tsx
+++ b/src/pages/Studies/StudiesSection/index.tsx
@@ -76,8 +76,8 @@ const StudiesSection = ({ isAdmin }: StudiesProps) => {
           studies &&
           studies
             .sort((a, b) =>
-              a.createdOn.value$kotlinx_datetime <
-              b.createdOn.value$kotlinx_datetime
+              a.createdOn <
+              b.createdOn
                 ? 1
                 : -1,
             )

--- a/src/pages/Studies/StudyCard/index.tsx
+++ b/src/pages/Studies/StudyCard/index.tsx
@@ -34,7 +34,7 @@ const StudyCard = ({ onClick, study, status, description }: Props) => {
             <Bottom>
               <CreationText variant="h5">
                 {formatDateTime(
-                  study.createdOn.value$kotlinx_datetime.toString(),
+                  study.createdOn.toString(),
                 )}
               </CreationText>
               {/* TODO: Add real owner name after backend supports it */}


### PR DESCRIPTION
As mentioned in cph-cachet/carp-client-ts#7, we don't need generated value for Instant.

However, using json serializer from carp.core brings another problem:
by default, null value is not serialized to `key: null`, but skipped instead. Therefore, undefined exception were thrown when access those values. 

I don't know how to correctly handle this situation here, so I added a null/undefined check when we access nullable types.
This should only affect `ParticipationGroups` for now.

I think we should come up with a more generalised rule on how webservices endpoint works: naming, nullable, structure, etc